### PR TITLE
[WIP] Add llama to sample factory

### DIFF
--- a/debug_discounting.py
+++ b/debug_discounting.py
@@ -1,0 +1,88 @@
+from typing import Optional, Union
+
+import torch
+from torch import Tensor
+
+buff = torch.load("tmp.pth")
+strategy_steps = buff["normalized_obs"]["strategy_steps"].squeeze()
+rewards = buff["rewards"]
+dones = buff["dones"].float()
+values = buff["values"]
+valids = buff["valids"].float()
+
+
+def calculate_conditioned_discounts(
+    x: Tensor, dones: Tensor, valids: Tensor, discount: float, x_last: Optional[Tensor] = None
+) -> Tensor:
+    """
+    Computing cumulative product of discounts for the trajectory conditioning on x, taking episode termination into consideration.
+    """
+    if x_last is None:
+        x_last = x[-1].clone().fill_(1.0)
+
+    cumulative = x_last
+
+    conditioned_discounts = torch.zeros_like(x)
+    i = 0
+    while i <= len(x) - 1:
+        # do not discount invalid steps so we can entirely skip a part of the trajectory
+        # x should be already multiplied by valids
+        discount_valid = discount * valids[i] + (1.0 - valids[i])
+        cumulative = discount_valid ** x[i] * cumulative * (1.0 - dones[i])
+        conditioned_discounts[i] = cumulative
+        i += 1
+
+    return conditioned_discounts
+
+
+def calculate_discounted_sum_torch(
+    x: Tensor, dones: Tensor, valids: Tensor, discount: Union[float, Tensor], x_last: Optional[Tensor] = None
+) -> Tensor:
+    """
+    Computing cumulative sum (of something) for the trajectory, taking episode termination into consideration.
+    """
+    if x_last is None:
+        x_last = x[-1].clone().fill_(0.0)
+
+    cumulative = x_last
+
+    discounted_sum = torch.zeros_like(x)
+    i = len(x) - 1
+    while i >= 0:
+        # do not discount invalid steps so we can entirely skip a part of the trajectory
+        # x should be already multiplied by valids
+        if isinstance(discount, float):
+            discount_valid = discount * valids[i] + (1 - valids[i])
+        else:
+            discount_valid = discount[i] * valids[i] + (1 - valids[i])
+        cumulative = x[i] + discount_valid * cumulative * (1.0 - dones[i])
+        discounted_sum[i] = cumulative
+        i -= 1
+
+    return discounted_sum
+
+
+def gae_advantages_conditioned(
+    rewards: Tensor, dones: Tensor, values: Tensor, valids: Tensor, γ: float, λ: float, strategy_steps: Tensor
+) -> Tensor:
+    strategy_steps = strategy_steps.transpose(0, 1)  # [E, T] -> [T, E]
+    rewards = rewards.transpose(0, 1)  # [E, T] -> [T, E]
+    dones = dones.transpose(0, 1).float()  # [E, T] -> [T, E]
+    values = values.transpose(0, 1)  # [E, T+1] -> [T+1, E]
+    valids = valids.transpose(0, 1).float()  # [E, T+1] -> [T+1, E]
+
+    assert len(rewards) == len(dones)
+    assert len(rewards) + 1 == len(values)
+
+    # section 3 in GAE paper: calculating advantages
+    deltas = (rewards - values[:-1]) * valids[:-1] + (1 - dones) * (γ * values[1:] * valids[1:])
+
+    γ = calculate_conditioned_discounts(strategy_steps[:-1], dones=dones, valids=valids[:-1], discount=γ)
+    advantages = calculate_discounted_sum_torch(deltas, dones, valids[:-1], γ * λ)
+
+    # transpose advantages back to [E, T] before creating a single experience buffer
+    advantages.transpose_(0, 1)
+    return advantages
+
+
+advantages = gae_advantages_conditioned(rewards, dones, values, valids, 0.99, 0.95, strategy_steps)

--- a/sample_factory/algo/learning/learner.py
+++ b/sample_factory/algo/learning/learner.py
@@ -18,7 +18,7 @@ from sample_factory.algo.utils.env_info import EnvInfo
 from sample_factory.algo.utils.misc import LEARNER_ENV_STEPS, POLICY_ID_KEY, STATS_KEY, TRAIN_STATS, memory_stats
 from sample_factory.algo.utils.model_sharing import ParameterServer
 from sample_factory.algo.utils.optimizers import Lamb
-from sample_factory.algo.utils.rl_utils import gae_advantages, prepare_and_normalize_obs
+from sample_factory.algo.utils.rl_utils import gae_advantages, gae_advantages_conditioned, prepare_and_normalize_obs
 from sample_factory.algo.utils.shared_buffers import policy_device
 from sample_factory.algo.utils.tensor_dict import TensorDict, shallow_recursive_copy
 from sample_factory.algo.utils.torch_utils import masked_select, synchronize, to_scalar
@@ -988,14 +988,26 @@ class Learner(Configurable):
 
             if not self.cfg.with_vtrace:
                 # calculate advantage estimate (in case of V-trace it is done separately for each minibatch)
-                buff["advantages"] = gae_advantages(
-                    buff["rewards"],
-                    buff["dones"],
-                    denormalized_values,
-                    buff["valids"],
-                    self.cfg.gamma,
-                    self.cfg.gae_lambda,
-                )
+                if self.cfg.hierarchical_gamma:
+                    assert "strategy_steps" in buff["normalized_obs"], "Hierarchical gamma requires strategy steps"
+                    buff["advantages"] = gae_advantages_conditioned(
+                        buff["rewards"],
+                        buff["dones"],
+                        denormalized_values,
+                        buff["valids"],
+                        self.cfg.gamma,
+                        self.cfg.gae_lambda,
+                        buff["normalized_obs"]["strategy_steps"].squeeze(),
+                    )
+                else:
+                    buff["advantages"] = gae_advantages(
+                        buff["rewards"],
+                        buff["dones"],
+                        denormalized_values,
+                        buff["valids"],
+                        self.cfg.gamma,
+                        self.cfg.gae_lambda,
+                    )
                 # here returns are not normalized yet, so we should use denormalized values
                 buff["returns"] = buff["advantages"] + buff["valids"][:, :-1] * denormalized_values[:, :-1]
 

--- a/sample_factory/algo/sampling/batched_sampling.py
+++ b/sample_factory/algo/sampling/batched_sampling.py
@@ -209,7 +209,11 @@ class BatchedVectorEnvRunner(VectorEnvRunner):
         num_dones = dones.sum().item()
 
         self.curr_episode_reward += rewards
-        self.curr_episode_len += self.env_info.frameskip if self.cfg.summaries_use_frameskip else 1
+        if "env_steps" in infos["episode_extra_stats"]:
+            for i, info in enumerate(infos):
+                self.curr_episode_len[i] += infos[i]["env_steps"]
+        else:
+            self.curr_episode_len += self.env_info.frameskip if self.cfg.summaries_use_frameskip else 1
 
         reports = []
         if num_dones <= 0:

--- a/sample_factory/algo/sampling/non_batched_sampling.py
+++ b/sample_factory/algo/sampling/non_batched_sampling.py
@@ -197,8 +197,11 @@ class ActorState:
         policy_id = -1 if not self.is_active else self.curr_policy_id
         self.curr_traj_buffer["policy_id"][rollout_step] = policy_id
 
-        # multiply by frameskip to get the episode lenghts matching the actual number of simulated steps
-        self.last_episode_duration += self.env_info.frameskip if self.cfg.summaries_use_frameskip else 1
+        if "env_steps" in info["episode_extra_stats"]:
+            self.last_episode_duration += info["episode_extra_stats"]["env_steps"]
+        else:
+            # multiply by frameskip to get the episode lenghts matching the actual number of simulated steps
+            self.last_episode_duration += self.env_info.frameskip if self.cfg.summaries_use_frameskip else 1
 
         self.is_active = info.get("is_active", True)
 

--- a/sample_factory/algo/utils/rl_utils.py
+++ b/sample_factory/algo/utils/rl_utils.py
@@ -50,7 +50,7 @@ def samples_per_trajectory(trajectory: TensorDict) -> int:
 
 @torch.jit.script
 def calculate_discounted_sum_torch(
-    x: Tensor, dones: Tensor, valids: Tensor, discount: float, x_last: Optional[Tensor] = None
+    x: Tensor, dones: Tensor, valids: Tensor, discount: Union[float, Tensor], x_last: Optional[Tensor] = None
 ) -> Tensor:
     """
     Computing cumulative sum (of something) for the trajectory, taking episode termination into consideration.
@@ -65,12 +65,65 @@ def calculate_discounted_sum_torch(
     while i >= 0:
         # do not discount invalid steps so we can entirely skip a part of the trajectory
         # x should be already multiplied by valids
-        discount_valid = discount * valids[i] + (1 - valids[i])
+        if isinstance(discount, float):
+            discount_valid = discount * valids[i] + (1 - valids[i])
+        else:
+            discount_valid = discount[i] * valids[i] + (1 - valids[i])
         cumulative = x[i] + discount_valid * cumulative * (1.0 - dones[i])
         discounted_sum[i] = cumulative
         i -= 1
 
     return discounted_sum
+
+
+@torch.jit.script
+def calculate_conditioned_discounts(
+    x: Tensor, dones: Tensor, valids: Tensor, discount: float, x_last: Optional[Tensor] = None
+) -> Tensor:
+    """
+    Computing cumulative product of discounts for the trajectory conditioning on x, taking episode termination into consideration.
+    """
+    if x_last is None:
+        x_last = x[-1].clone().fill_(1.0)
+
+    cumulative = x_last
+
+    conditioned_discounts = torch.zeros_like(x)
+    i = 0
+    while i <= len(x) - 1:
+        # do not discount invalid steps so we can entirely skip a part of the trajectory
+        # x should be already multiplied by valids
+        discount_valid = discount * valids[i] + (1.0 - valids[i])
+        cumulative = discount_valid ** x[i] * cumulative * (1.0 - dones[i])
+        conditioned_discounts[i] = cumulative
+        i += 1
+
+    return conditioned_discounts
+
+
+# noinspection NonAsciiCharacters
+@torch.jit.script
+def gae_advantages_conditioned(
+    rewards: Tensor, dones: Tensor, values: Tensor, valids: Tensor, γ: float, λ: float, strategy_steps: Tensor
+) -> Tensor:
+    strategy_steps = strategy_steps.transpose(0, 1)  # [E, T] -> [T, E]
+    rewards = rewards.transpose(0, 1)  # [E, T] -> [T, E]
+    dones = dones.transpose(0, 1).float()  # [E, T] -> [T, E]
+    values = values.transpose(0, 1)  # [E, T+1] -> [T+1, E]
+    valids = valids.transpose(0, 1).float()  # [E, T+1] -> [T+1, E]
+
+    assert len(rewards) == len(dones)
+    assert len(rewards) + 1 == len(values)
+
+    # section 3 in GAE paper: calculating advantages
+    deltas = (rewards - values[:-1]) * valids[:-1] + (1 - dones) * (γ * values[1:] * valids[1:])
+
+    γ = calculate_conditioned_discounts(strategy_steps[:-1], dones=dones, valids=valids[:-1], discount=γ)
+    advantages = calculate_discounted_sum_torch(deltas, dones, valids[:-1], γ * λ)
+
+    # transpose advantages back to [E, T] before creating a single experience buffer
+    advantages.transpose_(0, 1)
+    return advantages
 
 
 # noinspection NonAsciiCharacters

--- a/sample_factory/cfg/cfg.py
+++ b/sample_factory/cfg/cfg.py
@@ -246,6 +246,12 @@ def add_rl_args(p: ArgumentParser):
         help="Generalized Advantage Estimation discounting (only used when V-trace is False)",
     )
     p.add_argument(
+        "--hierarchical_gamma",
+        default=False,
+        type=str2bool,
+        help="Accounts for extra discounting when controlling high level policy.",
+    )
+    p.add_argument(
         "--ppo_clip_ratio",
         default=0.1,
         type=float,

--- a/sample_factory/model/actor_critic.py
+++ b/sample_factory/model/actor_critic.py
@@ -4,9 +4,7 @@ from typing import Dict, Optional
 
 import gymnasium as gym
 import torch
-from torch import Tensor, nn
-from torch.nn.utils.rnn import PackedSequence, pack_padded_sequence, pad_packed_sequence
-
+import torch.nn.functional as F
 from sample_factory.algo.utils.action_distributions import is_continuous_action_space, sample_actions_log_probs
 from sample_factory.algo.utils.running_mean_std import RunningMeanStdInPlace, running_mean_std_summaries
 from sample_factory.algo.utils.tensor_dict import TensorDict
@@ -18,6 +16,9 @@ from sample_factory.model.action_parameterization import (
 from sample_factory.model.model_utils import model_device
 from sample_factory.utils.normalize import ObservationNormalizer
 from sample_factory.utils.typing import ActionSpace, Config, ObsSpace
+from torch import Tensor, nn
+from torch.nn.utils.rnn import PackedSequence, pack_padded_sequence, pad_packed_sequence
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
 class ActorCritic(nn.Module, Configurable):
@@ -322,6 +323,199 @@ class ActorCriticSeparateWeights(ActorCritic):
         return result
 
 
+INSTRUCTION_PROMPT = """
+You are an agent playing MiniHack. The following are the possible high-level strategies you can take in the game, followed by a short description of each strategy:
+
+{skill_list}
+
+Each observation in the game is character-based. Here is a legend for what each character represents in the observation:
+    @: the player
+    #: a corridor
+    +: a closed door
+    |: a vertical wall
+    -: a horizontal wall
+    .: the floor
+    <: stairs leading up
+    >: stairs leading down
+
+Please output the strategy you would like to take when prompted with an observation in the following format:
+STRATEGY: <your_strategy> 
+Note that you can only pick from the strategies given above.
+"""
+
+import pdb
+import sys
+
+
+class ForkedPdb(pdb.Pdb):
+    """A Pdb subclass that works well with forking."""
+
+    def interaction(self, *args, **kwargs):
+        _stdin = sys.stdin
+        sys.stdin = open("/dev/stdin")
+        pdb.Pdb.interaction(self, *args, **kwargs)
+        sys.stdin = _stdin
+
+
+class LMActorCriticSeparateWeights(ActorCriticSeparateWeights):
+    def __init__(
+        self,
+        model_factory,
+        obs_space: ObsSpace,
+        action_space: ActionSpace,
+        cfg: Config,
+    ):
+        super().__init__(model_factory, obs_space, action_space, cfg)
+
+        skill_list = ""
+        for _, s in enumerate(cfg.strategies, 1):
+            skill_list += f"- {s}\n"
+        self.system_prompt = INSTRUCTION_PROMPT.format(skill_list=skill_list)
+
+        self.critic_encoder = model_factory.make_model_encoder_func(cfg, obs_space)
+        self.critic_core = model_factory.make_model_core_func(cfg, self.critic_encoder.get_out_size())
+
+        self.encoders = [self.critic_encoder]
+        self.cores = [self.critic_core]
+
+        self.core_func = self._core_rnn if self.cfg.use_rnn else self._core_empty
+
+        self.critic_decoder = model_factory.make_model_decoder_func(cfg, self.critic_core.get_out_size())
+        self.decoders = [self.critic_decoder]
+
+        self.critic_linear = nn.Linear(self.critic_decoder.get_out_size(), 1)
+        self.action_parameterization = self.get_action_parameterization(self.critic_decoder.get_out_size())
+
+        self.apply(self.initialize_weights)
+
+        # NOTE: needs to come *after* weight initialization so pre-trained weights aren't lost!
+        self.tokenizer = AutoTokenizer.from_pretrained(cfg.lm_model_name)
+        self.tokenizer.pad_token = (
+            self.tokenizer.eos_token
+        )  # TODO: I'm still not entirely sure if this is the right thing to do
+        self.actor = AutoModelForCausalLM.from_pretrained(
+            cfg.lm_model_name,
+            # attn_implementation="flash_attention_2", # NOTE: messes up generations for some reason - turn off for now
+            torch_dtype=torch.bfloat16,
+        )
+
+        self.pad_token_id = self.actor.config.eos_token_id[0]
+
+    def forward_tail(
+        self, core_output, values_only: bool, sample_actions: bool, action_mask: Optional[Tensor] = None
+    ) -> TensorDict:
+        core_outputs = core_output.chunk(len(self.cores), dim=1)
+
+        # second core output corresponds to the critic
+        critic_decoder_output = self.critic_decoder(core_outputs[0])
+        values = self.critic_linear(critic_decoder_output).squeeze()
+
+        result = TensorDict(values=values)
+        if values_only:
+            # this can be further optimized - we don't need to calculate actor head/core just to get values
+            return result
+
+        return result
+
+    def _create_messages_from_obs(self, obs):
+        messages = []
+
+        batched_tty_chars = obs["tty_chars"].cpu().numpy()
+        for tty_char in batched_tty_chars:
+            text_obs = ""
+            for line in tty_char:
+                text_obs += "".join([chr(c) for c in line]) + "\n"
+
+            messages.append(
+                [
+                    {"role": "system", "content": self.system_prompt},
+                    {"role": "user", "content": text_obs},
+                ]
+            )
+
+        return messages
+
+    def _preprocess_messages(self, messages):
+        tokenized_messages = self.tokenizer.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            continue_final_message=False,  # TODO: double check this
+            return_dict=True,
+            return_tensors="pt",
+            padding=True,
+            # **tokenizer_kwargs, # TODO: check if anything else needed here
+        )
+
+        # move to device
+        for key in tokenized_messages:
+            tokenized_messages[key] = tokenized_messages[key].to(model_device(self))
+
+        return tokenized_messages
+
+    def _actions_and_logits(self, tokenized_messages):
+        generated_sequence = self.actor.generate(
+            input_ids=tokenized_messages["input_ids"],
+            attention_mask=tokenized_messages["attention_mask"],
+            max_new_tokens=50,
+            output_scores=True,
+            return_dict_in_generate=True,
+            # **generate_kwargs # TODO: check if anything else needed here
+        )
+
+        logits = generated_sequence.scores
+        generated_tokens = generated_sequence.sequences[:, tokenized_messages["input_ids"].shape[1] :]
+
+        return generated_tokens, logits
+
+    def _log_probs_from_logits(self, logits, generated_tokens):
+        logits = torch.stack(logits)  # T x B x V
+        logits = logits.permute(1, 0, 2)  # Rearrange to B x T x V
+        log_softmaxed_logits = F.log_softmax(logits, dim=-1)  # Shape: B x T x V
+        gathered_log_probs = log_softmaxed_logits.gather(
+            dim=2, index=generated_tokens.unsqueeze(-1)
+        )  # Shape: B x T x 1
+        gathered_log_probs = gathered_log_probs.squeeze(-1)  # Shape: B x T
+
+        padding_mask = generated_tokens != self.pad_token_id  # Shape: B x T
+        masked_log_probs = gathered_log_probs.masked_fill(~padding_mask, 0.0)
+
+        total_log_prob = masked_log_probs.sum(dim=1)  # Shape: B
+
+        return total_log_prob
+
+    def forward(
+        self, normalized_obs_dict, rnn_states, values_only=False, action_mask: Optional[Tensor] = None
+    ) -> TensorDict:
+        x = self.forward_head(normalized_obs_dict)
+        x, new_rnn_states = self.forward_core(x, rnn_states)
+        result = self.forward_tail(x, values_only, sample_actions=True, action_mask=action_mask)
+
+        # (1) generate actions and (2) record log probabilities
+        if not values_only:
+            messages = self._create_messages_from_obs(normalized_obs_dict)
+            tokenized_messages = self._preprocess_messages(messages)
+            generated_tokens, logits = self._actions_and_logits(tokenized_messages)
+            log_probs = self._log_probs_from_logits(logits, generated_tokens)
+
+            # NOTE: decoding is only for debugging
+            # generated_tokens_list = generated_tokens.cpu().numpy().tolist()
+            # for sequence in generated_tokens_list:
+            #     text = self.tokenizer.decode(
+            #         sequence,
+            #         skip_special_tokens=True,
+            #         clean_up_tokenization_spaces=True,
+            #     )
+            #     print(text)
+
+            result["log_prob_actions"] = log_probs
+            result["actions"] = generated_tokens
+            # NOTE: action logits aren't used for LM model, so we just set them to zeros
+            result["action_logits"] = torch.zeros((log_probs.shape[0], 10), device=log_probs.device)
+
+        result["new_rnn_states"] = new_rnn_states
+        return result
+
+
 def default_make_actor_critic_func(cfg: Config, obs_space: ObsSpace, action_space: ActionSpace) -> ActorCritic:
     from sample_factory.algo.utils.context import global_model_factory
 
@@ -334,12 +528,27 @@ def default_make_actor_critic_func(cfg: Config, obs_space: ObsSpace, action_spac
         return ActorCriticSeparateWeights(model_factory, obs_space, action_space, cfg)
 
 
+import pdb
+import sys
+
+
+class ForkedPdb(pdb.Pdb):
+    """A Pdb subclass that works well with forking."""
+
+    def interaction(self, *args, **kwargs):
+        _stdin = sys.stdin
+        sys.stdin = open("/dev/stdin")
+        pdb.Pdb.interaction(self, *args, **kwargs)
+        sys.stdin = _stdin
+
+
 def create_actor_critic(cfg: Config, obs_space: ObsSpace, action_space: ActionSpace) -> ActorCritic:
     # check if user specified custom actor/critic creation function
     from sample_factory.algo.utils.context import global_model_factory
 
     make_actor_critic_func = global_model_factory().make_actor_critic_func
-    return make_actor_critic_func(cfg, obs_space, action_space)
+    return make_actor_critic_func(global_model_factory(), obs_space, action_space, cfg)
+    # return make_actor_critic_func(cfg, obs_space, action_space)
 
 
 def obs_space_without_action_mask(obs_space: ObsSpace) -> ObsSpace:


### PR DESCRIPTION
What we have so far:
- Added `LMActorCriticSeparateWeights` class which contains action generation and log probs calculation

**TODO:**
- [ ] Allow the results of the forward pass to be passed to the learner. Seems like we'll need to do some buffer adjustments here (start by looking at `alloc_policy_output_tensors`).
    - This is also because the length of the actions is non-standard + they can vary across batches that come in. Part of the solution could be to always pad actions to be the same length. 
- [ ] Add support for the `log_prob(mb.actions)` call in the learner. 
- [ ] Add KL with respect to the reference model as another loss term.